### PR TITLE
update the way the find dependence includes  path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 import os
 import sys
+import numpy
 
 from distutils.core import setup
 from distutils.extension import Extension
@@ -83,6 +84,7 @@ setup(
                            extra_compile_args=flags + ["-fopenmp"],
                            extra_link_args=['-fopenmp']),
                  ],
+    include_dirs = [numpy.get_include()],
     classifiers=[
         "Programming Language :: Cython",
         "Programming Language :: C++",


### PR DESCRIPTION
when some one install the numpy through anaconda, the package is no longer installed in /usr/bin/lib, get_include() could dynamic find the correct path.
